### PR TITLE
refactor: use slices.Contains to simplify

### DIFF
--- a/x/staking/msg_server.go
+++ b/x/staking/msg_server.go
@@ -2,6 +2,7 @@ package staking
 
 import (
 	"context"
+	"slices"
 	"strconv"
 	"time"
 
@@ -89,13 +90,7 @@ func (k msgServer) CreateValidator(goCtx context.Context, msg *types.MsgCreateVa
 	cp := ctx.ConsensusParams()
 	if cp != nil && cp.Validator != nil {
 		pkType := pk.Type()
-		hasKeyType := false
-		for _, keyType := range cp.Validator.PubKeyTypes {
-			if pkType == keyType {
-				hasKeyType = true
-				break
-			}
-		}
+		hasKeyType := slices.Contains(cp.Validator.PubKeyTypes, pkType)
 		if !hasKeyType {
 			return nil, sdkerrors.Wrapf(
 				types.ErrValidatorPubKeyTypeNotSupported,

--- a/x/tokenfactory/types/capabilities.go
+++ b/x/tokenfactory/types/capabilities.go
@@ -1,5 +1,7 @@
 package types
 
+import "slices"
+
 const (
 	EnableSetMetadata   = "enable_metadata"
 	EnableForceTransfer = "enable_force_transfer"
@@ -11,11 +13,5 @@ func IsCapabilityEnabled(enabledCapabilities []string, capability string) bool {
 		return true
 	}
 
-	for _, v := range enabledCapabilities {
-		if v == capability {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(enabledCapabilities, capability)
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.